### PR TITLE
Modify files to better replicate error and demonstrate workaround.

### DIFF
--- a/web/case-02-indirect-assignment.php
+++ b/web/case-02-indirect-assignment.php
@@ -11,7 +11,8 @@ $template = <<<'HTML'
     <meta charset="utf-8"/>
     <title>Example Code to demonstrate issue 57</title>
     <p>
-        <span tal:content="foo"></span>
+	<span>A Closure</span><br/>
+        <span tal:content="foo/nested"></span>
     </p>
 </html>
 HTML;
@@ -20,9 +21,9 @@ $engine = new PHPTAL();
 
 $engine->setSource($template);
 
-// Direct asignment
+// Closure
 $foo = function () {
-    return 'Foo';
+    return ['nested'=>'nestedfoo'];
 };
 
 $engine->foo = $foo;

--- a/web/case-03-indirect-assignment-workaround.php
+++ b/web/case-03-indirect-assignment-workaround.php
@@ -11,8 +11,8 @@ $template = <<<'HTML'
     <meta charset="utf-8"/>
     <title>Example Code to demonstrate issue 57</title>
     <p>
-	<span>Not a closure</span><br/>
-        <span tal:content="foo/nested"></span>
+	<span>A Closure using repeat</span><br/>
+        <span tal:repeat="f foo" tal:content="f/nested"></span>
     </p>
 </html>
 HTML;
@@ -21,10 +21,12 @@ $engine = new PHPTAL();
 
 $engine->setSource($template);
 
-//Not a closure, function is executed and result assigned.
-$engine->foo = (function () {
-    return ['nested'=>'nestedfoo'];
-})();
+// Closure
+$foo = function () {
+    return [['nested'=>'nestedfoo']]; //extra layer needed
+};
+
+$engine->foo = $foo;
 
 try {
     $result = $engine->execute();

--- a/web/index.html
+++ b/web/index.html
@@ -4,5 +4,6 @@
     <p>
         <a href="./case-01-direct-assignment.php">Direct Assignment</a>
         <a href="./case-02-indirect-assignment.php">Indirect Assignment</a>
+        <a href="./case-03-indirect-assignment-workaround.php">Indirect Assignment with Workaround</a>
     </p>
 </html>


### PR DESCRIPTION
It appears that the issue only shows up if the returned type is an array.
I can access`foo/nested` with `tal:content="foo/nested"` when it is not a closure, but when it is a closure I cannot access it the same way. I can however access it if I put it in a deeper array and then use `repeat`
Let me know if this works.